### PR TITLE
Fix cut off element in sidebar

### DIFF
--- a/assets/styles/aside.scss
+++ b/assets/styles/aside.scss
@@ -1,5 +1,5 @@
 aside {
-  width: 300px;
+  width: 310px;
   height: 100vh;
 
   position: fixed;
@@ -72,7 +72,7 @@ aside {
 
   nav {
     height: 100%; 
-    padding-bottom: 40px; // leave some space for the top search bar
+    padding-bottom: 60px; // leave some space for the top search bar
   }
 
   .group {


### PR DESCRIPTION
Fixes #9.

Increasing the width makes the container large enough for the search button to sit on the same line as the search bar.

Adding padding to the bottom of the nav because if you have a narrower screen, a horizontal scrollbar is shown at the bottom of the window which covers the last items in the list.