### PR TITLE
Fixes nav links that showed a cursor in the padding while not being c…

### DIFF
--- a/templates/assets/styles/v-docs.css
+++ b/templates/assets/styles/v-docs.css
@@ -311,18 +311,17 @@ header .header-container .logo img {
 
 .nav-entry {
   line-height: 1.5em;
-  display: flex;
-  flex-direction: column;
   color: var(--secondary-color) !important;
-  padding: 6px 2px;
 }
 .nav-entry > a {
+  display: block;
+  padding: 6px 2px;
   text-decoration: none;
   color: inherit !important;
 }
-
-
-
+.nav-entry > a:hover {
+  color: var(--color) !important;
+}
 
 .nav-entry.is-group-header{
   font-size: 1.1em;
@@ -333,11 +332,6 @@ header .header-container .logo img {
   color: var(--theme-color) !important;
 }
 
-.nav-entry:hover {
-  cursor: pointer;
-  color: var(--color) !important;
-}
-
 .nav-entry.is-search-result {
   color: var(--theme-color) !important;
 }
@@ -345,11 +339,12 @@ header .header-container .logo img {
 .nav-entry > .nav-entry-text {
   font-size: 0.9em;
   font-style: italic;
-  padding-left: 6px;
+  padding-left: 8px;
+  margin: 6px 0;
   color: var(--secondary-color) !important;
 }
 
-.nav-group > .nav-group-body > .nav-entry {
+.nav-group > .nav-group-body > .nav-entry > a {
   padding-left: 16px !important;
 }
 


### PR DESCRIPTION
In the nav bar, the section links show up as clickable (the mouse cursor turns into a pointer finger) in places where they're actually not. More precisely, when hovering over the padding above and below the actual link. This is incredibly frustrating.

![Screenshot_2025-06-29_19-00-56](https://github.com/user-attachments/assets/8b7d95d9-d13a-401c-83c6-7ac4cff1c214)

The fix is simple: remove the padding from the enclosing div and the fake "pointer on hover" styling, and simply put padding to the actual `<a>` element.

The same issue was also found in search results where the whole search text was shown as clickable but wasn't. This fixes it too.