### PR TITLE
Fix "try in playground" URLs broken when b64 contains +

### DIFF
--- a/templates/assets/scripts/v-docs.js
+++ b/templates/assets/scripts/v-docs.js
@@ -337,8 +337,9 @@ vdocs.examples = {
 
 		el.querySelector('.v-code-btn-run').addEventListener('click', (evt)=>{
 
-			let code = editor.getValue();
-			let url = "https://play.vlang.io/?base64=" + btoa(code);
+			const code = editor.getValue();
+			const b64 = btoa(code);
+			const url = "https://play.vlang.io/?base64=" + encodeURIComponent(b64);
 
 			window.open(url, "_blank");
 


### PR DESCRIPTION
The "Try it in the playground" links in code blocks are broken when the base64 encoding of the code contains the character `+`, as it is a reserved character in URLs which gets replaced by a space on the playground's end, which completely breaks the code.

Example: the first code block of this section https://docs.vlang.io/functions-2.html#lambda-expressions

Should be

```v
mut a := [1, 2, 3]
a.sort(|x, y| x > y) // sorts the array, defining the comparator with a lambda expression
println(a.map(|x| x * 10)) // prints [30, 20, 10]
```

But in the playground it opens like so:

![image](https://github.com/user-attachments/assets/4d96ab10-5646-45e1-9e28-4921971faec8)

Some blocks are even more broken, such as this one https://docs.vlang.io/concurrency.html#channel-select which makes the playground fail to display anything.

The fix is simple, correctly encode the query param value.